### PR TITLE
Fixing delete functionality

### DIFF
--- a/code/forms/FrontEndGridFieldDetailForm.php
+++ b/code/forms/FrontEndGridFieldDetailForm.php
@@ -39,7 +39,9 @@ class FrontEndGridFieldDetailForm_ItemRequest extends GridFieldDetailForm_ItemRe
     public function edit($request) {
         $controller=$this->getToplevelController();
         $form=$this->ItemEditForm($this->gridField, $request);
-        
+
+        Requirements::javascript(THIRDPARTY_DIR . '/jquery/jquery.js');
+        Requirements::javascript(FRONTEND_GRIDFIELD_BASE.'/javascript/closeparentdialog.js');
         
         return $controller->customise(array(
                                     'Title'=>($this->record && $this->record->ID ? $this->record->Title:sprintf(_t('GridField.NewRecord', 'New %s'), $this->record->i18n_singular_name())),

--- a/javascript/FrontEndGridField.js
+++ b/javascript/FrontEndGridField.js
@@ -61,7 +61,8 @@
                                     self.getGridField().reload();
                                 }
                             });
-                
+                //store a global reference
+                window.fegf_dialog = dialog;
                 
                 e.preventDefault();
                 return false;
@@ -92,7 +93,8 @@
                                     self.getGridField().reload();
                                 }
                             });
-                
+                //store a global reference
+                window.fegf_dialog = dialog;
                 
                 e.preventDefault();
                 return false;

--- a/javascript/FrontEndGridField.js
+++ b/javascript/FrontEndGridField.js
@@ -22,22 +22,14 @@
             }
         });
         
-        
-        $('.ss-gridfield:not(.ss-gridfield-editable) button.gridfield-button-delete').entwine({
+        $('.ss-gridfield:not(.ss-gridfield-editable) .col-buttons .action.gridfield-button-delete, .cms-edit-form .Actions button.action.action-delete').entwine({
             /**
              * Function: onclick
              */
             onclick: function(e) {
-                // Confirmation on delete. 
-                if(!confirm(ss.i18n._t('TABLEFIELD.DELETECONFIRMMESSAGE'))) {
-                    e.preventDefault();
-                    return false;
-                }
+                this._super(e);
                 
-                if(!this.is(':disabled')) {
-                    this.parents('form').trigger('submit', [this]);
-                }
-                
+                //prevent parent td selector events from being fired
                 e.preventDefault();
                 return false;
             }

--- a/javascript/closeparentdialog.js
+++ b/javascript/closeparentdialog.js
@@ -1,0 +1,9 @@
+(function($, dialog) {
+	//bind to form submission (submission has started)
+	$('form .Actions button[name=action_doDelete]').click(function(e){
+		//bind to unload event (submission has completed)
+		$(window).unload(function() {
+			dialog.fegfdialog("close");
+		});
+	});
+})(jQuery, window.parent.fegf_dialog);


### PR DESCRIPTION
In my approach, I adjusted the js for the row action to just preform the default (GridField.js) functionality, but it additionally prevents the default action - so you don't get the entwined 'td' firing, which would open the lightbox.

For the delete function within the lightbox iframe, I've included javascript that calls the parent frame's close dialog function.

No worries if nothing is of use.